### PR TITLE
Add persistence: dump aggregator state on shutdown, reload on start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ config
 !config/default.js
 !config/example.js
 !config/express_websocket_example.js
+.hyperwatch-data
 node_modules
 package-lock.json

--- a/src/app/api.js
+++ b/src/app/api.js
@@ -6,6 +6,7 @@ const { stringify } = require('csv-stringify/sync');
 const express = require('express');
 
 const monitoring = require('../lib/monitoring');
+const persistence = require('../lib/persistence');
 const { formatTable } = require('../lib/util');
 const stylesheet = require('../stylesheet');
 
@@ -88,6 +89,7 @@ body { display: flex; flex-direction: column-reverse; }
 };
 
 app.registerAggregator = (name, aggregator) => {
+  persistence.register(name, aggregator);
   app.get(`/${name}.:format(json|csv)?`, (req, res) => {
     const raw = req.query.raw ? true : false;
     const format = req.params.format || (raw ? 'json' : null);

--- a/src/constants.js
+++ b/src/constants.js
@@ -57,7 +57,7 @@ const constants = {
     },
   },
   persistence: {
-    enabled: true,
+    enabled: false,
     path: null,
     namespace: null,
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -56,6 +56,11 @@ const constants = {
       priority: 800,
     },
   },
+  persistence: {
+    enabled: true,
+    path: null,
+    namespace: null,
+  },
 };
 
 module.exports = rc('hyperwatch', constants);

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const { merge } = require('lodash');
 
 const app = require('./app');
@@ -8,9 +10,17 @@ const lib = require('./lib');
 const modules = require('./modules');
 const plugins = require('./plugins');
 
-const { cache, logger, pipeline, util } = lib;
+const { cache, logger, persistence, pipeline, util } = lib;
 
 let initialized = false;
+
+function getPersistenceDir() {
+  const base =
+    constants.persistence.path || path.join(process.cwd(), '.hyperwatch-data');
+  return constants.persistence.namespace
+    ? path.join(base, constants.persistence.namespace)
+    : base;
+}
 
 function init(config = {}) {
   if (initialized) {
@@ -28,10 +38,20 @@ function start() {
     return;
   }
   modules.start();
+  if (constants.persistence.enabled) {
+    persistence.load(getPersistenceDir());
+  }
   return Promise.all([app.start(), pipeline.start()]);
 }
 
 function stop() {
+  try {
+    if (constants.persistence.enabled) {
+      persistence.dump(getPersistenceDir());
+    }
+  } catch (err) {
+    console.error('Error dumping aggregators:', err.message);
+  }
   return Promise.all([app.stop(), pipeline.stop()]);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,8 @@ function start() {
   return Promise.all([app.start(), pipeline.start()]);
 }
 
-function stop() {
+async function stop() {
+  await pipeline.stop();
   try {
     if (constants.persistence.enabled) {
       persistence.dump(getPersistenceDir());
@@ -52,7 +53,7 @@ function stop() {
   } catch (err) {
     console.error('Error dumping aggregators:', err.message);
   }
-  return Promise.all([app.stop(), pipeline.stop()]);
+  return app.stop();
 }
 
 module.exports = {

--- a/src/lib/aggregator.js
+++ b/src/lib/aggregator.js
@@ -1,4 +1,4 @@
-const { Map, Set, is } = require('immutable');
+const { Map, Set, fromJS, is } = require('immutable');
 
 const { Formatter, address, identity } = require('../lib/formatter');
 const { Speed } = require('../lib/speed');
@@ -66,7 +66,7 @@ class Aggregator {
     this.sorters = defaultSorters;
     this.gcSize = 1000;
 
-    setInterval(() => this.gc(), 60 * 1000);
+    setInterval(() => this.gc(), 60 * 1000).unref();
   }
 
   setFormatter(fn) {
@@ -163,6 +163,40 @@ class Aggregator {
     }
 
     this.entries = this.entries.filter((value, key) => keepList.has(key));
+  }
+
+  dump() {
+    return this.entries
+      .map((entry) => {
+        const plain = entry.toJS();
+        plain.speed = {
+          per_minute: entry.getIn(['speed', 'per_minute']).toJSON(),
+          per_hour: entry.getIn(['speed', 'per_hour']).toJSON(),
+        };
+        return plain;
+      })
+      .valueSeq()
+      .toArray();
+  }
+
+  load(data) {
+    for (const item of data) {
+      const { speed, ...rest } = item;
+      // fromJS deep-converts everything to Immutable structures.
+      // Signature headers must stay as a plain object (used with Object.entries),
+      // and addresses must be a Set, not a List — fix both after conversion.
+      let entry = fromJS(rest);
+      if (entry.hasIn(['signature', 'headers'])) {
+        entry = entry.setIn(['signature', 'headers'], rest.signature.headers);
+      }
+      if (entry.has('addresses')) {
+        entry = entry.update('addresses', (list) => Set(list));
+      }
+      entry = entry
+        .setIn(['speed', 'per_minute'], Speed.fromJSON(speed.per_minute))
+        .setIn(['speed', 'per_hour'], Speed.fromJSON(speed.per_hour));
+      this.entries = this.entries.set(rest.id, entry);
+    }
   }
 }
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -2,6 +2,7 @@ const aggregator = require('./aggregator');
 const cache = require('./cache');
 const formatter = require('./formatter');
 const logger = require('./logger');
+const persistence = require('./persistence');
 const pipeline = require('./pipeline');
 const util = require('./util');
 
@@ -10,6 +11,7 @@ module.exports = {
   cache,
   formatter,
   logger,
+  persistence,
   pipeline,
   util,
 };

--- a/src/lib/persistence.js
+++ b/src/lib/persistence.js
@@ -1,7 +1,9 @@
-const debug = require('debug')('hyperwatch:persistence');
-
 const fs = require('fs');
 const path = require('path');
+
+const debug = require('debug');
+
+const debugPersistence = debug('hyperwatch:persistence');
 
 const aggregators = Object.create(null);
 
@@ -25,14 +27,24 @@ function dump(dir) {
     fs.writeFileSync(tmp, JSON.stringify(data));
     fs.renameSync(tmp, target);
   }
-  debug(`Dumped ${Object.keys(aggregators).length} aggregator(s) to ${dir}`);
+  debugPersistence(
+    `Dumped ${Object.keys(aggregators).length} aggregator(s) to ${dir}`
+  );
 }
 
 function load(dir) {
   if (!fs.existsSync(dir)) {
     return;
   }
-  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+  let files;
+  try {
+    files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+  } catch (err) {
+    debugPersistence(
+      `Cannot read persistence directory ${dir}: ${err.message}`
+    );
+    return;
+  }
   let loaded = 0;
   for (const file of files) {
     const name = path.basename(file, '.json');
@@ -40,18 +52,20 @@ function load(dir) {
       try {
         const data = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
         if (!Array.isArray(data)) {
-          debug(`Skipping ${file}: expected array, got ${typeof data}`);
+          debugPersistence(
+            `Skipping ${file}: expected array, got ${typeof data}`
+          );
           continue;
         }
         aggregators[name].load(data);
         loaded += data.length;
       } catch (err) {
-        debug(`Skipping ${file}: ${err.message}`);
+        debugPersistence(`Skipping ${file}: ${err.message}`);
       }
     }
   }
   if (loaded) {
-    debug(`Loaded ${loaded} entries from ${dir}`);
+    debugPersistence(`Loaded ${loaded} entries from ${dir}`);
   }
 }
 

--- a/src/lib/persistence.js
+++ b/src/lib/persistence.js
@@ -1,0 +1,42 @@
+const debug = require('debug')('hyperwatch:persistence');
+
+const fs = require('fs');
+const path = require('path');
+
+const aggregators = {};
+
+function register(name, aggregator) {
+  aggregators[name] = aggregator;
+}
+
+function dump(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  for (const [name, aggregator] of Object.entries(aggregators)) {
+    const data = aggregator.dump();
+    fs.writeFileSync(path.join(dir, `${name}.json`), JSON.stringify(data));
+  }
+  debug(`Dumped ${Object.keys(aggregators).length} aggregator(s) to ${dir}`);
+}
+
+function load(dir) {
+  if (!fs.existsSync(dir)) {
+    return;
+  }
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+  let loaded = 0;
+  for (const file of files) {
+    const name = path.basename(file, '.json');
+    if (aggregators[name]) {
+      const data = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+      aggregators[name].load(data);
+      loaded += data.length;
+    }
+  }
+  if (loaded) {
+    debug(`Loaded ${loaded} entries from ${dir}`);
+  }
+}
+
+module.exports = { register, dump, load };

--- a/src/lib/persistence.js
+++ b/src/lib/persistence.js
@@ -3,9 +3,14 @@ const debug = require('debug')('hyperwatch:persistence');
 const fs = require('fs');
 const path = require('path');
 
-const aggregators = {};
+const aggregators = Object.create(null);
+
+const SAFE_NAME = /^[A-Za-z0-9._-]+$/;
 
 function register(name, aggregator) {
+  if (!SAFE_NAME.test(name)) {
+    throw new Error(`Invalid aggregator name for persistence: "${name}"`);
+  }
   aggregators[name] = aggregator;
 }
 
@@ -15,7 +20,10 @@ function dump(dir) {
   }
   for (const [name, aggregator] of Object.entries(aggregators)) {
     const data = aggregator.dump();
-    fs.writeFileSync(path.join(dir, `${name}.json`), JSON.stringify(data));
+    const target = path.join(dir, `${name}.json`);
+    const tmp = path.join(dir, `${name}.json.tmp`);
+    fs.writeFileSync(tmp, JSON.stringify(data));
+    fs.renameSync(tmp, target);
   }
   debug(`Dumped ${Object.keys(aggregators).length} aggregator(s) to ${dir}`);
 }
@@ -29,9 +37,17 @@ function load(dir) {
   for (const file of files) {
     const name = path.basename(file, '.json');
     if (aggregators[name]) {
-      const data = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
-      aggregators[name].load(data);
-      loaded += data.length;
+      try {
+        const data = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+        if (!Array.isArray(data)) {
+          debug(`Skipping ${file}: expected array, got ${typeof data}`);
+          continue;
+        }
+        aggregators[name].load(data);
+        loaded += data.length;
+      } catch (err) {
+        debug(`Skipping ${file}: ${err.message}`);
+      }
     }
   }
   if (loaded) {

--- a/src/lib/speed.js
+++ b/src/lib/speed.js
@@ -34,12 +34,11 @@ class Speed {
     return this;
   }
 
-  compute() {
+  compute(time = now()) {
     this.gc();
     if (!this.started) {
       return List();
     }
-    const time = now();
     return Range(0, this.size)
       .map((n) => {
         let t = time - n * this.windowSize;
@@ -51,12 +50,11 @@ class Speed {
       .filter((v) => v !== undefined);
   }
 
-  computeSum() {
+  computeSum(time = now()) {
     this.gc();
     if (!this.started) {
       return List();
     }
-    const time = now();
     return Range(0, this.size)
       .map((n) => {
         let t = time - n * this.windowSize;

--- a/src/lib/speed.js
+++ b/src/lib/speed.js
@@ -67,6 +67,26 @@ class Speed {
       })
       .filter((v) => v !== undefined);
   }
+
+  toJSON() {
+    return {
+      windowSize: this.windowSize,
+      size: this.size,
+      counters: this.counters.toObject(),
+      sums: this.sums.toObject(),
+      started: this.started,
+      latest: this.latest,
+    };
+  }
+
+  static fromJSON(data) {
+    const speed = new Speed(data.windowSize, data.size);
+    speed.counters = Map(data.counters);
+    speed.sums = Map(data.sums);
+    speed.started = data.started;
+    speed.latest = data.latest;
+    return speed;
+  }
 }
 
 module.exports = {

--- a/test/lib/persistence.js
+++ b/test/lib/persistence.js
@@ -1,0 +1,256 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { Map, Set, fromJS } = require('immutable');
+
+const { Aggregator } = require('../../src/lib/aggregator');
+const { Speed } = require('../../src/lib/speed');
+const { now } = require('../../src/lib/util');
+
+describe('Speed serialization', () => {
+  it('toJSON returns plain object with all fields', () => {
+    const s = new Speed(60, 15);
+    const t = now();
+    s.hit(t, 100);
+    s.hit(t, 200);
+
+    const json = s.toJSON();
+    assert.strictEqual(json.windowSize, 60);
+    assert.strictEqual(json.size, 15);
+    assert.strictEqual(json.started, t);
+    assert.strictEqual(json.latest, t);
+    assert.strictEqual(typeof json.counters, 'object');
+    assert.strictEqual(typeof json.sums, 'object');
+  });
+
+  it('fromJSON restores a working Speed instance', () => {
+    const s = new Speed(10, 5);
+    const t = now();
+    s.hit(t - 30, 100);
+    s.hit(t - 30, 200);
+    s.hit(t - 10, 50);
+
+    const restored = Speed.fromJSON(s.toJSON());
+    assert.deepStrictEqual(restored.compute().toJS(), s.compute().toJS());
+    assert.deepStrictEqual(restored.computeSum().toJS(), s.computeSum().toJS());
+    assert.strictEqual(restored.started, s.started);
+    assert.strictEqual(restored.latest, s.latest);
+  });
+
+  it('fromJSON Speed accepts new hits', () => {
+    const s = new Speed(10, 5);
+    const t = now();
+    s.hit(t - 10, 50);
+
+    const restored = Speed.fromJSON(s.toJSON());
+    restored.hit(t, 75);
+    assert.deepStrictEqual(restored.compute().toJS(), [1, 1]);
+    assert.deepStrictEqual(restored.computeSum().toJS(), [75, 50]);
+  });
+});
+
+describe('Aggregator dump/load', () => {
+  it('round-trips entries with speed data', () => {
+    const agg = new Aggregator();
+    const t = now();
+
+    // Simulate two entries
+    agg.entries = agg.entries
+      .setIn(['a', 'id'], 'a')
+      .setIn(['a', 'identifier'], '1.2.3.4')
+      .setIn(['a', 'speed', 'per_minute'], new Speed(60, 15).hit(t, 100))
+      .setIn(['a', 'speed', 'per_hour'], new Speed(3600, 24).hit(t, 100))
+      .setIn(['b', 'id'], 'b')
+      .setIn(['b', 'identifier'], '5.6.7.8')
+      .setIn(['b', 'speed', 'per_minute'], new Speed(60, 15).hit(t, 50))
+      .setIn(['b', 'speed', 'per_hour'], new Speed(3600, 24).hit(t, 50));
+
+    const dumped = agg.dump();
+    assert.strictEqual(dumped.length, 2);
+
+    const agg2 = new Aggregator();
+    agg2.load(dumped);
+    assert.strictEqual(agg2.entries.size, 2);
+    assert.strictEqual(agg2.entries.getIn(['a', 'identifier']), '1.2.3.4');
+    assert.strictEqual(agg2.entries.getIn(['b', 'identifier']), '5.6.7.8');
+
+    const pm = agg2.entries.getIn(['a', 'speed', 'per_minute']);
+    assert(pm instanceof Speed);
+    assert.deepStrictEqual(pm.compute().toJS(), [1]);
+  });
+
+  it('preserves enriched metadata (address, agent, geoip, identity)', () => {
+    const agg = new Aggregator();
+    const t = now();
+
+    agg.entries = agg.entries
+      .setIn(['a', 'id'], 'a')
+      .setIn(['a', 'identifier'], '1.2.3.4')
+      .setIn(['a', 'speed', 'per_minute'], new Speed(60, 15).hit(t))
+      .setIn(['a', 'speed', 'per_hour'], new Speed(3600, 24).hit(t))
+      .setIn(['a', 'identity'], 'Googlebot')
+      .setIn(
+        ['a', 'address'],
+        fromJS({ value: '1.2.3.4', hostname: 'bot.google.com' })
+      )
+      .setIn(
+        ['a', 'agent'],
+        fromJS({ family: 'Googlebot', major: '2', os: { family: 'Other' } })
+      )
+      .setIn(
+        ['a', 'geoip'],
+        fromJS({ country: 'US', city: 'Mountain View', ll: [37.4, -122.1] })
+      )
+      .setIn(
+        ['a', 'language'],
+        fromJS([{ code: 'en', region: 'US', quality: 1 }])
+      );
+
+    const agg2 = new Aggregator();
+    agg2.load(agg.dump());
+
+    const entry = agg2.entries.get('a');
+    assert.strictEqual(entry.get('identity'), 'Googlebot');
+    assert.strictEqual(entry.getIn(['address', 'hostname']), 'bot.google.com');
+    assert.strictEqual(entry.getIn(['agent', 'os']).get('family'), 'Other');
+    assert.strictEqual(entry.getIn(['geoip', 'country']), 'US');
+    assert.strictEqual(entry.getIn(['language', 0, 'code']), 'en');
+  });
+
+  it('restores signature.headers as a plain object', () => {
+    const agg = new Aggregator();
+    const t = now();
+
+    const headers = { Accept: 'text/html', 'User-Agent': 'Bot/1.0' };
+    agg.entries = agg.entries
+      .setIn(['a', 'id'], 'a')
+      .setIn(['a', 'identifier'], 'sig-abc')
+      .setIn(['a', 'speed', 'per_minute'], new Speed(60, 15).hit(t))
+      .setIn(['a', 'speed', 'per_hour'], new Speed(3600, 24).hit(t))
+      .setIn(['a', 'signature'], Map({ id: 'abc', headers }));
+
+    const agg2 = new Aggregator();
+    agg2.load(agg.dump());
+
+    const restored = agg2.entries.getIn(['a', 'signature', 'headers']);
+    assert.strictEqual(typeof restored, 'object');
+    assert.ok(!restored.toJS, 'headers should not be an Immutable Map');
+    assert.deepStrictEqual(Object.entries(restored), [
+      ['Accept', 'text/html'],
+      ['User-Agent', 'Bot/1.0'],
+    ]);
+  });
+
+  it('restores addresses as an Immutable Set', () => {
+    const agg = new Aggregator();
+    const t = now();
+
+    agg.entries = agg.entries
+      .setIn(['a', 'id'], 'a')
+      .setIn(['a', 'identifier'], 'sig-abc')
+      .setIn(['a', 'speed', 'per_minute'], new Speed(60, 15).hit(t))
+      .setIn(['a', 'speed', 'per_hour'], new Speed(3600, 24).hit(t))
+      .set(
+        'a',
+        agg.entries.get('a', Map()).merge(
+          Map({
+            id: 'a',
+            identifier: 'sig-abc',
+            addresses: Set([
+              Map({ value: '1.2.3.4' }),
+              Map({ value: '5.6.7.8' }),
+            ]),
+          })
+        )
+      )
+      .setIn(['a', 'speed', 'per_minute'], new Speed(60, 15).hit(t))
+      .setIn(['a', 'speed', 'per_hour'], new Speed(3600, 24).hit(t));
+
+    const agg2 = new Aggregator();
+    agg2.load(agg.dump());
+
+    const addresses = agg2.entries.getIn(['a', 'addresses']);
+    assert.ok(Set.isSet(addresses), 'addresses should be an Immutable Set');
+    assert.strictEqual(addresses.size, 2);
+    // Set.add should work (this is what signature enricher does)
+    const updated = addresses.add(Map({ value: '9.9.9.9' }));
+    assert.strictEqual(updated.size, 3);
+  });
+
+  it('loaded entries accept new hits from processLog', () => {
+    const { md5 } = require('../../src/lib/util');
+
+    const agg = new Aggregator();
+    const t = now();
+    const identifier = '1.2.3.4';
+    const id = md5(identifier);
+
+    agg.entries = agg.entries
+      .setIn([id, 'id'], id)
+      .setIn([id, 'identifier'], identifier)
+      .setIn([id, 'speed', 'per_minute'], new Speed(60, 15).hit(t, 10))
+      .setIn([id, 'speed', 'per_hour'], new Speed(3600, 24).hit(t, 10));
+
+    const agg2 = new Aggregator();
+    agg2.load(agg.dump());
+
+    // processLog with matching identifier should update existing entry
+    agg2.setIdentifier((log) => log.getIn(['address', 'value']));
+    const log = fromJS({
+      request: { address: '1.2.3.4' },
+      address: { value: '1.2.3.4' },
+      executionTime: 25,
+    });
+    agg2.processLog(log);
+
+    const pm = agg2.entries.getIn([id, 'speed', 'per_minute']);
+    // Should now have 2 hits
+    assert.strictEqual(
+      pm.compute().reduce((a, b) => a + b, 0),
+      2
+    );
+  });
+});
+
+describe('persistence dump / load', () => {
+  let tmpDir;
+  const persistence = require('../../src/lib/persistence');
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hyperwatch-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes and reads JSON files per aggregator', () => {
+    const agg = new Aggregator();
+    const t = now();
+    agg.entries = agg.entries
+      .setIn(['x', 'id'], 'x')
+      .setIn(['x', 'identifier'], '10.0.0.1')
+      .setIn(['x', 'speed', 'per_minute'], new Speed(60, 15).hit(t))
+      .setIn(['x', 'speed', 'per_hour'], new Speed(3600, 24).hit(t));
+
+    persistence.register('test-agg', agg);
+
+    persistence.dump(tmpDir);
+    assert.ok(fs.existsSync(path.join(tmpDir, 'test-agg.json')));
+
+    // Create a fresh aggregator and load
+    const agg2 = new Aggregator();
+    persistence.register('test-agg', agg2);
+    persistence.load(tmpDir);
+
+    assert.strictEqual(agg2.entries.size, 1);
+    assert.strictEqual(agg2.entries.getIn(['x', 'identifier']), '10.0.0.1');
+  });
+
+  it('skips load when directory does not exist', () => {
+    persistence.load(path.join(tmpDir, 'nonexistent'));
+    // Should not throw
+  });
+});

--- a/test/lib/persistence.js
+++ b/test/lib/persistence.js
@@ -33,8 +33,11 @@ describe('Speed serialization', () => {
     s.hit(t - 10, 50);
 
     const restored = Speed.fromJSON(s.toJSON());
-    assert.deepStrictEqual(restored.compute().toJS(), s.compute().toJS());
-    assert.deepStrictEqual(restored.computeSum().toJS(), s.computeSum().toJS());
+    assert.deepStrictEqual(restored.compute(t).toJS(), s.compute(t).toJS());
+    assert.deepStrictEqual(
+      restored.computeSum(t).toJS(),
+      s.computeSum(t).toJS()
+    );
     assert.strictEqual(restored.started, s.started);
     assert.strictEqual(restored.latest, s.latest);
   });
@@ -46,8 +49,8 @@ describe('Speed serialization', () => {
 
     const restored = Speed.fromJSON(s.toJSON());
     restored.hit(t, 75);
-    assert.deepStrictEqual(restored.compute().toJS(), [1, 1]);
-    assert.deepStrictEqual(restored.computeSum().toJS(), [75, 50]);
+    assert.deepStrictEqual(restored.compute(t).toJS(), [1, 1]);
+    assert.deepStrictEqual(restored.computeSum(t).toJS(), [75, 50]);
   });
 });
 
@@ -78,7 +81,7 @@ describe('Aggregator dump/load', () => {
 
     const pm = agg2.entries.getIn(['a', 'speed', 'per_minute']);
     assert(pm instanceof Speed);
-    assert.deepStrictEqual(pm.compute().toJS(), [1]);
+    assert.deepStrictEqual(pm.compute(t).toJS(), [1]);
   });
 
   it('preserves enriched metadata (address, agent, geoip, identity)', () => {
@@ -208,7 +211,7 @@ describe('Aggregator dump/load', () => {
     const pm = agg2.entries.getIn([id, 'speed', 'per_minute']);
     // Should now have 2 hits
     assert.strictEqual(
-      pm.compute().reduce((a, b) => a + b, 0),
+      pm.compute(t).reduce((a, b) => a + b, 0),
       2
     );
   });


### PR DESCRIPTION
Saves all aggregator entries (speed counters, enriched metadata) to JSON files on shutdown and restores them on start, preserving traffic stats across restarts.

- Speed: add toJSON/fromJSON for serializing windowed counters
- Aggregator: add dump/load with correct Immutable structure handling (fromJS for deep conversion, Set restoration, plain object leaves)
- New lib/persistence module: aggregator registry + file I/O
- Configurable via persistence.enabled, persistence.path, persistence.namespace
- Aggregator GC timer uses unref() to not block process exit