### PR TITLE
Add firewall module: rule-based request classification

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -49,6 +49,10 @@ const constants = {
       active: false,
       priority: 620, // depends on: agent, hostname, signature, address
     },
+    firewall: {
+      active: false,
+      priority: 650, // requires: all enrichment; injects into address aggregator
+    },
     // --- Output: depends on full enrichment ---
     history: {
       active: false,

--- a/src/lib/aggregator.js
+++ b/src/lib/aggregator.js
@@ -46,6 +46,7 @@ const defaultEnricher = (entry, log) => {
     'identity',
     'cloudflare',
     'dnsbl',
+    'firewall',
     'geoip',
     'hostname',
     'agent',

--- a/src/modules/address.js
+++ b/src/modules/address.js
@@ -30,6 +30,7 @@ function start() {
       'identity',
       'cloudflare',
       'dnsbl',
+      'firewall',
       'geoip',
       'hostname',
       'agent',

--- a/src/modules/firewall.js
+++ b/src/modules/firewall.js
@@ -15,22 +15,54 @@ const signature = require('./signature');
 
 let rules = [];
 
-function loadRules() {
-  const filePath =
+function rulesPath() {
+  return (
     (constants.modules.firewall && constants.modules.firewall.path) ||
-    path.join(process.cwd(), 'firewall.json');
+    path.join(process.cwd(), 'firewall.json')
+  );
+}
 
+function compileRules(data) {
+  if (!data || (data.rules !== undefined && !Array.isArray(data.rules))) {
+    throw new TypeError('rules must be an array');
+  }
+
+  return (data.rules || []).map((rule) => {
+    if (!rule || typeof rule !== 'object' || Array.isArray(rule)) {
+      throw new TypeError('each rule must be an object');
+    }
+
+    const compiled = { ...rule };
+    if (!rule.match) {
+      return compiled;
+    }
+    if (typeof rule.match !== 'object' || Array.isArray(rule.match)) {
+      throw new TypeError('rule match must be an object');
+    }
+
+    compiled.match = { ...rule.match };
+    if (rule.match.ua_regex) {
+      compiled._ua_regex = new RegExp(rule.match.ua_regex);
+    }
+    if (rule.match.cidrs) {
+      if (!Array.isArray(rule.match.cidrs)) {
+        throw new TypeError('rule match.cidrs must be an array');
+      }
+      compiled._cidrs = rule.match.cidrs.map((cidr) => new IPCIDR(cidr));
+    }
+    return compiled;
+  });
+}
+
+function loadRules(filePath = rulesPath()) {
   try {
     const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-    rules = (data.rules || []).map((rule) => {
-      if (rule.match && rule.match.ua_regex) {
-        rule._ua_regex = new RegExp(rule.match.ua_regex);
-      }
-      return rule;
-    });
+    const nextRules = compileRules(data);
+    rules = nextRules;
+    return true;
   } catch (err) {
     console.warn(`firewall: could not load ${filePath}: ${err.message}`);
-    rules = [];
+    return false;
   }
 }
 
@@ -59,10 +91,7 @@ function matchRule(log, rule) {
   if (match.cidrs) {
     const address =
       log.getIn(['address', 'value']) || log.getIn(['request', 'address']);
-    if (
-      !address ||
-      !match.cidrs.some((cidr) => new IPCIDR(cidr).contains(address))
-    ) {
+    if (!address || !rule._cidrs.some((cidr) => cidr.contains(address))) {
       return false;
     }
   }
@@ -172,9 +201,7 @@ function init() {
   loadRules();
 
   // Watch for changes to the rules file
-  const filePath =
-    (constants.modules.firewall && constants.modules.firewall.path) ||
-    path.join(process.cwd(), 'firewall.json');
+  const filePath = rulesPath();
 
   fs.watchFile(filePath, { interval: 5000 }, () => {
     console.log('firewall: reloading rules');
@@ -252,10 +279,11 @@ function start() {
 
 function getExplicitAction(address) {
   for (const rule of rules) {
-    if (rule.match.address === address) {
+    const match = rule.match || {};
+    if (match.address === address) {
       return rule.action;
     }
-    if (rule.match.addresses && rule.match.addresses.includes(address)) {
+    if (match.addresses && match.addresses.includes(address)) {
       return rule.action;
     }
   }
@@ -264,10 +292,11 @@ function getExplicitAction(address) {
 
 function getSignatureAction(sig) {
   for (const rule of rules) {
-    if (rule.match.signature === sig) {
+    const match = rule.match || {};
+    if (match.signature === sig) {
       return rule.action;
     }
-    if (rule.match.signatures && rule.match.signatures.includes(sig)) {
+    if (match.signatures && match.signatures.includes(sig)) {
       return rule.action;
     }
   }
@@ -280,10 +309,11 @@ const firewallFormat = (entry) =>
 const addressFirewallRuleFormat = (entry) => {
   const addr = entry.getIn(['address', 'value']);
   for (const rule of rules) {
-    if (rule.match.address === addr) {
+    const match = rule.match || {};
+    if (match.address === addr) {
       return rule.id;
     }
-    if (rule.match.addresses && rule.match.addresses.includes(addr)) {
+    if (match.addresses && match.addresses.includes(addr)) {
       return rule.id;
     }
   }
@@ -316,4 +346,10 @@ const signatureFirewallRuleFormat = (entry) => {
   return '';
 };
 
-module.exports = { init, start, getExplicitAction, getSignatureAction };
+module.exports = {
+  init,
+  start,
+  getExplicitAction,
+  getSignatureAction,
+  _testing: { loadRules, augment },
+};

--- a/src/modules/firewall.js
+++ b/src/modules/firewall.js
@@ -1,0 +1,319 @@
+const fs = require('fs');
+const path = require('path');
+
+const IPCIDR = require('ip-cidr').default;
+
+const api = require('../app/api');
+const constants = require('../constants');
+const { Aggregator } = require('../lib/aggregator');
+const { Formatter } = require('../lib/formatter');
+const pipeline = require('../lib/pipeline');
+const { aggregateCount, aggregateSum, formatDuration } = require('../lib/util');
+
+const address = require('./address');
+const signature = require('./signature');
+
+let rules = [];
+
+function loadRules() {
+  const filePath =
+    (constants.modules.firewall && constants.modules.firewall.path) ||
+    path.join(process.cwd(), 'firewall.json');
+
+  try {
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    rules = (data.rules || []).map((rule) => {
+      if (rule.match && rule.match.ua_regex) {
+        rule._ua_regex = new RegExp(rule.match.ua_regex);
+      }
+      return rule;
+    });
+  } catch (err) {
+    console.warn(`firewall: could not load ${filePath}: ${err.message}`);
+    rules = [];
+  }
+}
+
+function matchRule(log, rule) {
+  const match = rule.match;
+  if (!match) {
+    return false;
+  }
+
+  if (match.address) {
+    const address =
+      log.getIn(['address', 'value']) || log.getIn(['request', 'address']);
+    if (address !== match.address) {
+      return false;
+    }
+  }
+
+  if (match.addresses) {
+    const address =
+      log.getIn(['address', 'value']) || log.getIn(['request', 'address']);
+    if (!match.addresses.includes(address)) {
+      return false;
+    }
+  }
+
+  if (match.cidrs) {
+    const address =
+      log.getIn(['address', 'value']) || log.getIn(['request', 'address']);
+    if (
+      !address ||
+      !match.cidrs.some((cidr) => new IPCIDR(cidr).contains(address))
+    ) {
+      return false;
+    }
+  }
+
+  if (match.asns) {
+    const asnNumber = log.getIn(['asn', 'number']);
+    if (!asnNumber || !match.asns.includes(asnNumber)) {
+      return false;
+    }
+  }
+
+  if (match.identity) {
+    if (log.get('identity') !== match.identity) {
+      return false;
+    }
+  }
+
+  if (match.no_identity) {
+    if (log.has('identity')) {
+      return false;
+    }
+  }
+
+  if (match.signature) {
+    if (log.getIn(['signature', 'id']) !== match.signature) {
+      return false;
+    }
+  }
+
+  if (match.signatures) {
+    if (!match.signatures.includes(log.getIn(['signature', 'id']))) {
+      return false;
+    }
+  }
+
+  if (match.headers) {
+    for (const [header, value] of Object.entries(match.headers)) {
+      if (log.getIn(['request', 'headers', header]) !== value) {
+        return false;
+      }
+    }
+  }
+
+  if (match.headers_contain) {
+    for (const [header, value] of Object.entries(match.headers_contain)) {
+      const actual = log.getIn(['request', 'headers', header]) || '';
+      if (!actual.includes(value)) {
+        return false;
+      }
+    }
+  }
+
+  if (match.cookie_contains) {
+    const cookie = log.getIn(['request', 'headers', 'cookie']) || '';
+    if (!cookie.includes(match.cookie_contains)) {
+      return false;
+    }
+  }
+
+  if (match.missing_headers) {
+    for (const header of match.missing_headers) {
+      if (log.hasIn(['request', 'headers', header])) {
+        return false;
+      }
+    }
+  }
+
+  if (match.min_fingerprint_score !== undefined) {
+    const score = log.getIn(['fingerprint', 'score']) || 0;
+    if (score < match.min_fingerprint_score) {
+      return false;
+    }
+  }
+
+  if (match.user_agents) {
+    const ua = log.getIn(['request', 'headers', 'user-agent']) || '';
+    if (!match.user_agents.includes(ua)) {
+      return false;
+    }
+  }
+
+  if (rule._ua_regex) {
+    const ua = log.getIn(['request', 'headers', 'user-agent']) || '';
+    if (!rule._ua_regex.test(ua)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function augment(log) {
+  for (const rule of rules) {
+    if (matchRule(log, rule)) {
+      return log.set('firewall', {
+        action: rule.action,
+        rule: rule.id,
+        reason: rule.reason,
+        explicit: !!(rule.match.address || rule.match.addresses),
+      });
+    }
+  }
+  return log;
+}
+
+function init() {
+  loadRules();
+
+  // Watch for changes to the rules file
+  const filePath =
+    (constants.modules.firewall && constants.modules.firewall.path) ||
+    path.join(process.cwd(), 'firewall.json');
+
+  fs.watchFile(filePath, { interval: 5000 }, () => {
+    console.log('firewall: reloading rules');
+    loadRules();
+  });
+
+  pipeline.getNode('main').map(augment).registerNode('main');
+}
+
+function start() {
+  const aggregator = new Aggregator();
+
+  aggregator.setIdentifier((log) => log.getIn(['firewall', 'rule']));
+
+  const firewallFormatter = new Formatter();
+
+  firewallFormatter.setFormats([
+    ['rule', (entry) => entry.getIn(['firewall', 'rule'])],
+    ['action', (entry) => entry.getIn(['firewall', 'action'])],
+    ['reason', (entry) => entry.getIn(['firewall', 'reason'])],
+    [
+      'cloudflare',
+      (entry) => {
+        const ruleId = entry.getIn(['firewall', 'rule']);
+        const rule = rules.find((r) => r.id === ruleId);
+        return rule && rule.cloudflare ? rule.cloudflare.id : '';
+      },
+    ],
+    ['count15m', (entry) => aggregateCount(entry, 'per_minute')],
+    ['count24h', (entry) => aggregateCount(entry, 'per_hour')],
+    [
+      'execTime15m',
+      (entry) => formatDuration(aggregateSum(entry, 'per_minute')),
+    ],
+    ['execTime24h', (entry) => formatDuration(aggregateSum(entry, 'per_hour'))],
+  ]);
+
+  aggregator.setFormatter(firewallFormatter);
+
+  const enricher = (entry, log) => {
+    if (log.has('firewall') && !entry.has('firewall')) {
+      entry = entry.set('firewall', log.get('firewall'));
+    }
+    return entry;
+  };
+
+  aggregator.setEnricher(enricher);
+
+  pipeline.getNode('main').map((log) => {
+    if (log.has('firewall')) {
+      aggregator.processLog(log);
+    }
+    return log;
+  }, 'aggregator');
+
+  api.registerAggregator('firewall', aggregator);
+
+  // Inject firewall columns into address aggregator
+  address.aggregator.formatter.insertFormat('firewall', firewallFormat);
+  address.aggregator.formatter.insertFormat(
+    'firewallRule',
+    addressFirewallRuleFormat
+  );
+
+  // Inject firewall columns into signature aggregator
+  signature.aggregator.formatter.insertFormat(
+    'firewall',
+    signatureFirewallFormat
+  );
+  signature.aggregator.formatter.insertFormat(
+    'firewallRule',
+    signatureFirewallRuleFormat
+  );
+}
+
+function getExplicitAction(address) {
+  for (const rule of rules) {
+    if (rule.match.address === address) {
+      return rule.action;
+    }
+    if (rule.match.addresses && rule.match.addresses.includes(address)) {
+      return rule.action;
+    }
+  }
+  return null;
+}
+
+function getSignatureAction(sig) {
+  for (const rule of rules) {
+    if (rule.match.signature === sig) {
+      return rule.action;
+    }
+    if (rule.match.signatures && rule.match.signatures.includes(sig)) {
+      return rule.action;
+    }
+  }
+  return null;
+}
+
+const firewallFormat = (entry) =>
+  getExplicitAction(entry.getIn(['address', 'value'])) || '';
+
+const addressFirewallRuleFormat = (entry) => {
+  const addr = entry.getIn(['address', 'value']);
+  for (const rule of rules) {
+    if (rule.match.address === addr) {
+      return rule.id;
+    }
+    if (rule.match.addresses && rule.match.addresses.includes(addr)) {
+      return rule.id;
+    }
+  }
+  return '';
+};
+
+const signatureFirewallFormat = (entry) => {
+  const fw = entry.get('firewall');
+  if (fw) {
+    const action =
+      typeof fw === 'object' && fw.action
+        ? fw.action
+        : fw.get && fw.get('action');
+    if (action) {
+      return action;
+    }
+  }
+  return getSignatureAction(entry.getIn(['signature', 'id'])) || '';
+};
+
+const signatureFirewallRuleFormat = (entry) => {
+  const fw = entry.get('firewall');
+  if (fw) {
+    return (
+      (typeof fw === 'object' && fw.rule
+        ? fw.rule
+        : fw.get && fw.get('rule')) || ''
+    );
+  }
+  return '';
+};
+
+module.exports = { init, start, getExplicitAction, getSignatureAction };

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -15,6 +15,8 @@ function get(module) {
       return require('./cloudflare');
     case 'dnsbl':
       return require('./dnsbl');
+    case 'firewall':
+      return require('./firewall');
     case 'geoip':
       return require('./geoip');
     case 'history':

--- a/src/modules/signature.js
+++ b/src/modules/signature.js
@@ -138,6 +138,12 @@ function start() {
       }
     }
 
+    // Firewall status follows latest log — cleared when rule is removed
+    const firewall = log.get('firewall') || null;
+    if (!is(firewall, entry.get('firewall'))) {
+      entry = entry.set('firewall', firewall);
+    }
+
     const address = log.get('address');
     entry = entry.set('lastAddress', address);
     if (!entry.has('addresses')) {

--- a/test/modules/firewall.js
+++ b/test/modules/firewall.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { fromJS } = require('immutable');
+
+const firewall = require('../../src/modules/firewall');
+
+describe('Firewall rules', () => {
+  let directory;
+  let filePath;
+  let warn;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'hyperwatch-firewall-'));
+    filePath = path.join(directory, 'firewall.json');
+    warn = console.warn;
+    console.warn = () => {};
+  });
+
+  afterEach(() => {
+    console.warn = warn;
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  function writeRules(rules) {
+    fs.writeFileSync(filePath, JSON.stringify({ rules }));
+  }
+
+  it('matches valid CIDRs without compiling them for every request', () => {
+    writeRules([
+      { id: 'private', action: 'allow', match: { cidrs: ['10.0.0.0/8'] } },
+    ]);
+
+    assert.strictEqual(firewall._testing.loadRules(filePath), true);
+    const log = firewall._testing.augment(
+      fromJS({ request: { address: '10.1.2.3' } })
+    );
+    assert.strictEqual(log.getIn(['firewall', 'rule']), 'private');
+  });
+
+  it('keeps the last valid rules when a reload contains invalid JSON', () => {
+    writeRules([
+      { id: 'blocked', action: 'block', match: { address: '192.0.2.1' } },
+    ]);
+    assert.strictEqual(firewall._testing.loadRules(filePath), true);
+
+    fs.writeFileSync(filePath, '{');
+    assert.strictEqual(firewall._testing.loadRules(filePath), false);
+    assert.strictEqual(firewall.getExplicitAction('192.0.2.1'), 'block');
+  });
+
+  it('rejects invalid CIDRs while keeping the last valid rules', () => {
+    writeRules([
+      { id: 'blocked', action: 'block', match: { address: '192.0.2.1' } },
+    ]);
+    assert.strictEqual(firewall._testing.loadRules(filePath), true);
+
+    writeRules([{ id: 'invalid', action: 'block', match: { cidrs: ['bad'] } }]);
+    assert.strictEqual(firewall._testing.loadRules(filePath), false);
+    assert.strictEqual(firewall.getExplicitAction('192.0.2.1'), 'block');
+  });
+
+  it('safely ignores rules without match criteria in formatter lookups', () => {
+    writeRules([
+      { id: 'disabled', action: 'block' },
+      { id: 'signature', action: 'allow', match: { signature: 'abc' } },
+    ]);
+
+    assert.strictEqual(firewall._testing.loadRules(filePath), true);
+    assert.strictEqual(firewall.getExplicitAction('192.0.2.1'), null);
+    assert.strictEqual(firewall.getSignatureAction('abc'), 'allow');
+  });
+});


### PR DESCRIPTION
Split out of #545 to keep that PR focused on aggregator counters and endpoints.

Adds the `firewall` module (inactive by default): loads rules from `firewall.json` (IP/CIDR, user-agent regex, identity matches), tags matching logs with the rule's action/reason, registers a `/firewall` aggregator endpoint, and injects a firewall column into the address and signature aggregators.

Stacked on #545 — based on `execution-time-aggregation`; will retarget to `main` when it merges. Note: overlaps with #545's follow-up in `constants.js`/`modules/index.js`/`signature.js`, so whichever of the two module PRs merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)