### PR TITLE
Upgrade geoip-lite to 2.x, require Node >= 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Hyperwatch is built on a real-time stream processor handling logs from inputs of
 
 ## Install
 
-Make sure you have Node.js version >= 20.
+Make sure you have Node.js version >= 24.
 
 We recommend using [nvm](https://github.com/creationix/nvm): `nvm install && nvm use`.
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dnsbl": "^4.0.3",
     "express": "^4.22.2",
     "express-ws": "^5.0.2",
-    "geoip-lite": "^1.4.10",
+    "geoip-lite": "^2.0.3",
     "immutable": "^5.1.9",
     "ip-cidr": "^4.0.2",
     "lodash": "^4.18.1",
@@ -65,7 +65,7 @@
     "prettier-package-json": "^2.8.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "depcheck": {
     "ignores": [


### PR DESCRIPTION
Upgrades geoip-lite from 1.4.10 to ^2.0.3.

- geoip-lite 2.x declares `engines: node >= 24`, so this bumps our own `engines` field and reduces the CI test matrix to Node 24.
- The GeoLite2 database remains bundled in the npm package, so installation stays a plain `npm install` — no license key or extra download steps.
- README updated to state the Node.js >= 24 requirement (`.nvmrc` already said 24).
- Verified locally on Node 24: full test suite passes (38 tests), and IPv4/IPv6 lookups against the bundled database work out of the box.

Supersedes #537 (same bump, but without the engines/CI alignment; 2.0.3 is a patch ahead of 2.0.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
