### PR TITLE
Add SofyaBot identity detection for sofya.co domain

### DIFF
--- a/src/modules/identity.js
+++ b/src/modules/identity.js
@@ -237,6 +237,10 @@ function augment(log) {
       return hostname && hostname.endsWith('.blex.seranking.com')
         ? log.set('identity', 'SE Ranking')
         : log;
+    case 'SofyaBot':
+      return hostname && hostname.endsWith('.sofya.co')
+        ? log.set('identity', 'Sofya')
+        : log;
 
     // Per hostname + CIDR
     case 'Twitterbot':


### PR DESCRIPTION
## Summary
Added bot identity detection for SofyaBot requests originating from the sofya.co domain.

## Changes
- Added a new case handler in the identity augmentation logic to detect SofyaBot user agent
- When SofyaBot is detected and the hostname ends with `.sofya.co`, the log identity is set to 'Sofya'
- Follows the existing pattern used for other bot/service identifications (e.g., SE Ranking)

## Implementation Details
The new detection rule is added to the hostname-based identity matching section of the `augment()` function, maintaining consistency with similar bot detection patterns already in place.

https://claude.ai/code/session_01HYyhB4Dm7RKzbj7ana4A4a