### PR TITLE
Add Node 26 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [24.x]
+        node-version: [24.x, 26.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds `26.x` to the test matrix alongside `24.x`.

- Node 26 is the current release line (v26.8.1 as of today) and becomes LTS on 2026-10-28; Node 25 reached end-of-life in June 2026, so it's skipped.
- `24.x` stays as the baseline, matching `engines.node >= 24` and `.nvmrc`.
- Verified locally on Node 26.8.1: 48 tests passing, `lint`, `prettier:check`, `depcheck` clean, geoip-lite 2.x lookups work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DR3x69jA285jqeKuoWfEW3