### PR TITLE
Add Exa (ExaSearchBot) identity

### DIFF
--- a/src/modules/identity.js
+++ b/src/modules/identity.js
@@ -25,6 +25,7 @@ function augment(log) {
   const address =
     log.getIn(['address', 'value']) || log.getIn(['request', 'address']);
   const signature = log.getIn(['signature', 'id']);
+  const signatureAgent = log.getIn(['request', 'headers', 'signature-agent']);
 
   switch (family) {
     // Per hostname
@@ -412,6 +413,15 @@ function augment(log) {
     case 'FlipboardProxy':
       return hostname && hostname.endsWith('.flipboard.com')
         ? log.set('identity', 'Flipboard')
+        : log;
+
+    // Web Bot Auth
+    case 'ExaSearchBot':
+      // Exa search crawler. No published IP ranges or reverse DNS: requests
+      // are signed (RFC 9421) and carry a `Signature-Agent` header
+      // https://crawler.exa.ai/
+      return signatureAgent && signatureAgent.includes('https://crawler.exa.ai')
+        ? log.set('identity', 'Exa')
         : log;
   }
 


### PR DESCRIPTION
## Summary

`ExaSearchBot` is the crawler behind Exa's search index. Observed traffic sends:

```
User-Agent: Mozilla/5.0 (compatible; ExaSearchBot/1.0; +https://crawler.exa.ai/)
Accept: text/markdown,text/html;q=0.9,application/xhtml+xml;q=0.8,application/xml;q=0.7,image/webp;q=0.6,*/*;q=0.5
Accept-Language: en-US,en;q=0.5
```

`@hyperwatch/useragent` already parses the family as `ExaSearchBot`, so only the identity mapping was missing.

## Verification

Unlike every other case in `identity.js`, Exa publishes no IP ranges and no reverse DNS convention. They verify crawlers with Web Bot Auth instead: every request is signed per RFC 9421 and carries a `Signature-Agent` header pointing at their Ed25519 key directory (`https://crawler.exa.ai/.well-known/http-message-signatures-directory`).

We don't validate signatures, so the identity is set when that header points at `crawler.exa.ai`:

```js
case 'ExaSearchBot':
  return signatureAgent && signatureAgent.includes('https://crawler.exa.ai')
    ? log.set('identity', 'Exa')
    : log;
```

This is weaker than the reverse DNS and CIDR checks used elsewhere — the header is as spoofable as the user agent — but it at least requires a spoofer to speak Web Bot Auth rather than just claim the user agent. A substring match because the value is a structured-field string, so it arrives quoted and may carry a trailing slash.

## Notes

- Header availability depends on the input: the express middleware and the JSON inputs carry all headers, while the nginx `combined` / `hyperwatch_combined` formats capture a fixed header list — on those, `$http_signature_agent` needs adding to the log format for this to match.
- If the observed addresses turn out to share a reverse DNS suffix, a hostname check can be added alongside, which would also cover the fixed-format inputs.
- Full RFC 9421 verification (fetching and caching the key directory, validating the Ed25519 signature over the signature base) would be a natural follow-up, and would also cover other crawlers moving to Web Bot Auth.

https://claude.ai/code/session_01BqPQzyvpD7Kcz1oJhRmvEz