### PR TITLE
Restrict CI workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- declare explicit read-only contents permission for the CI workflow
- satisfy CodeQL's missing-workflow-permissions checks for all CI jobs

Repository-wide Actions permissions are already read-only; this makes the workflow's least-privilege requirement explicit and resilient to future settings changes.