### PR TITLE
Update chalk to v6 and fix ESM default export imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "accept-language-parser": "^1.5.0",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
-    "chalk": "^4.1.2",
+    "chalk": "^6.0.0",
     "country-code-emoji": "^2.3.0",
     "csv-stringify": "^6.8.3",
     "debug": "^4.4.3",

--- a/src/lib/formatter.js
+++ b/src/lib/formatter.js
@@ -1,4 +1,4 @@
-const chalk = require('chalk');
+const { default: chalk } = require('chalk');
 
 const colorize = (name, value, output) => {
   if (output === 'console') {

--- a/test/lib/chalk.js
+++ b/test/lib/chalk.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 
-const chalk = require('chalk');
+const { default: chalk } = require('chalk');
 const { Map } = require('immutable');
 
 const { colorize, executionTime } = require('../../src/lib/formatter');


### PR DESCRIPTION
## Summary
Updates the chalk dependency to v6.0.0 and adapts the codebase to handle chalk's ESM default export pattern in CommonJS environments.

## Key Changes
- Upgraded chalk from ^4.1.2 to ^6.0.0 in package.json
- Updated chalk imports in `src/lib/formatter.js` to use destructured default export: `const { default: chalk } = require('chalk')`
- Updated chalk imports in `test/lib/chalk.js` to use the same destructured default export pattern

## Implementation Details
Chalk v6 changed its export structure, requiring a different import pattern in CommonJS modules. The destructuring of the `default` export (`const { default: chalk } = require('chalk')`) is necessary to properly access the chalk API when using CommonJS `require()` with the newer ESM-based chalk package.

https://claude.ai/code/session_01PYD4b54PcqiuW39Svkb8Rq